### PR TITLE
Implement separate address translation unit

### DIFF
--- a/isa-sim/sha3/sha3.h
+++ b/isa-sim/sha3/sha3.h
@@ -67,6 +67,9 @@ public:
 
         break;
 
+      case 2: // sfence
+        break;
+
       default:
         illegal_instruction();
     }

--- a/src/main/scala/ctrl.scala
+++ b/src/main/scala/ctrl.scala
@@ -76,6 +76,7 @@ class CtrlModule(val W: Int, val S: Int)(implicit val p: Parameters) extends Mod
   val rocc_rs2_reg = Reg(next=io.rocc_rs2)
   val rocc_rd_reg = Reg(next=io.rocc_rd)
 
+  val dmem_resp_val_reg = Reg(next=io.dmem_resp_val)
   val dmem_resp_tag_reg = Reg(next=io.dmem_resp_tag)
   //memory pipe state
   val fast_mem = p(Sha3FastMem)
@@ -674,7 +675,7 @@ class CtrlModule(val W: Int, val S: Int)(implicit val p: Parameters) extends Mod
     }
 
     //response
-    when(io.dmem_resp_val){
+    when(dmem_resp_val_reg){
       //there is a response from memory
       when(dmem_resp_tag_reg(4,0) >= UInt(round_size_words)) {
         //this is a response to a write

--- a/src/main/scala/ctrl.scala
+++ b/src/main/scala/ctrl.scala
@@ -43,6 +43,8 @@ class CtrlModule(val W: Int, val S: Int)(implicit val p: Parameters) extends Mod
     val dmem_resp_tag     = Bits(INPUT, 7)
     val dmem_resp_data    = Bits(INPUT, W)
 
+    val sfence            = Bool(OUTPUT)
+
     //Sha3 Specific signals
     val round       = UInt(OUTPUT,width=5)
     val stage       = UInt(OUTPUT,width=log2Up(S))
@@ -181,6 +183,7 @@ class CtrlModule(val W: Int, val S: Int)(implicit val p: Parameters) extends Mod
   io.dmem_req_addr:= Bits(0, 32)
   io.dmem_req_cmd:= M_XRD
   io.dmem_req_size:= log2Ceil(8).U
+  io.sfence      := Bool(false)
 
   val rindex_reg = Reg(next=rindex)
 
@@ -200,6 +203,12 @@ class CtrlModule(val W: Int, val S: Int)(implicit val p: Parameters) extends Mod
         io.rocc_req_rdy := Bool(true)
         io.busy := Bool(true)
         msg_len := io.rocc_rs1
+      }
+      if (p(Sha3TLB).isDefined) {
+        when (io.rocc_funct === UInt(2)) {
+          io.rocc_req_rdy := Bool(true)
+          io.sfence := Bool(true)
+        }
       }
     }
   }

--- a/src/main/scala/dmem.scala
+++ b/src/main/scala/dmem.scala
@@ -25,6 +25,7 @@ class DmemModuleImp(outer: DmemModule)(implicit p: Parameters) extends LazyModul
     val mem = Decoupled(new HellaCacheReq)
     val ptw = new TLBPTWIO
     val status = Valid(new MStatus).flip
+    val sfence = Bool(INPUT)
   })
 
   val (tl, edge) = outer.node.out.head
@@ -52,7 +53,11 @@ class DmemModuleImp(outer: DmemModule)(implicit p: Parameters) extends LazyModul
 
   io.ptw <> tlb.io.ptw
   tlb.io.ptw.status := status
-  tlb.io.sfence.valid := Bool(false) // FIXME
+  tlb.io.sfence.valid := io.sfence
+  tlb.io.sfence.bits.rs1 := Bool(false)
+  tlb.io.sfence.bits.rs2 := Bool(false)
+  tlb.io.sfence.bits.addr := UInt(0)
+  tlb.io.sfence.bits.asid := UInt(0)
 
   io.req.ready := Bool(false)
 

--- a/src/main/scala/dmem.scala
+++ b/src/main/scala/dmem.scala
@@ -1,0 +1,87 @@
+//see LICENSE for license
+//authors: Albert Ou
+package sha3
+
+import Chisel._
+import freechips.rocketchip.config.{Field, Parameters}
+import freechips.rocketchip.tile.HasCoreParameters
+import freechips.rocketchip.rocket.{HellaCacheReq, TLB, TLBPTWIO, TLBConfig, MStatus}
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.tilelink._
+
+case object Sha3TLB extends Field[Option[TLBConfig]](None)
+
+class DmemModule(implicit p: Parameters) extends LazyModule {
+  lazy val module = new DmemModuleImp(this)
+  // FIXME: Unused Diplomacy node needed for conveying the physical address map to the TLB
+  val node = TLClientNode(Seq(TLClientPortParameters(Seq(TLClientParameters("SHA3")))))
+}
+
+class DmemModuleImp(outer: DmemModule)(implicit p: Parameters) extends LazyModuleImp(outer)
+  with HasCoreParameters {
+
+  val io = IO(new Bundle {
+    val req = Decoupled(new HellaCacheReq).flip
+    val mem = Decoupled(new HellaCacheReq)
+    val ptw = new TLBPTWIO
+    val status = Valid(new MStatus).flip
+  })
+
+  val (tl, edge) = outer.node.out.head
+  // Tie off unused channels
+  tl.a.valid := Bool(false)
+  tl.b.ready := Bool(true)
+  tl.c.valid := Bool(false)
+  tl.d.ready := Bool(true)
+  tl.e.valid := Bool(false)
+
+  val status = Reg(new MStatus)
+  when (io.status.valid) {
+    status := io.status.bits
+  }
+
+  val s_tlb :: s_mem :: s_xcpt :: Nil = Enum(UInt(), 3)
+  val state = Reg(init = s_tlb)
+
+  val tlb = Module(new TLB(false, log2Ceil(coreDataBytes), p(Sha3TLB).get)(edge, p))
+  tlb.io.req.valid := Bool(false)
+  tlb.io.req.bits.vaddr := io.req.bits.addr
+  tlb.io.req.bits.size := io.req.bits.size
+  tlb.io.req.bits.cmd := io.req.bits.cmd
+  tlb.io.req.bits.passthrough := Bool(false)
+
+  io.ptw <> tlb.io.ptw
+  tlb.io.ptw.status := status
+  tlb.io.sfence.valid := Bool(false) // FIXME
+
+  io.req.ready := Bool(false)
+
+  io.mem.valid := Bool(false)
+  io.mem.bits := io.req.bits
+  io.mem.bits.addr := tlb.io.resp.paddr
+  io.mem.bits.signed := Bool(false)
+  io.mem.bits.phys := Bool(true)
+
+  val xcpt = Seq(tlb.io.resp.pf, tlb.io.resp.ae, tlb.io.resp.ma).
+    map(x => x.ld || x.st).reduce(_ || _)
+
+  switch (state) {
+    is (s_tlb) {
+      tlb.io.req.valid := io.req.valid
+      when (tlb.io.req.fire()) {
+        when (tlb.io.resp.miss || xcpt) {
+          state := s_xcpt
+        } .otherwise {
+          state := s_mem
+        }
+      }
+    }
+    is (s_mem) {
+      io.mem.valid := Bool(true)
+      io.req.ready := io.mem.ready
+      when (io.mem.ready) {
+        state := s_tlb
+      }
+    }
+  }
+}

--- a/src/main/scala/sha3.scala
+++ b/src/main/scala/sha3.scala
@@ -100,6 +100,7 @@ class Sha3AccelImp(outer: Sha3Accel)(implicit p: Parameters) extends LazyRoCCMod
 
       dmem.io.status.valid := io.cmd.fire()
       dmem.io.status.bits := io.cmd.bits.status
+      dmem.io.sfence := ctrl.io.sfence
     }
     case None => dmem_ctrl(io.mem.req)
   }


### PR DESCRIPTION
If an M-mode interrupt is taken while the SHA3 accelerator is running in a virtual memory environment, the accelerator will fault and hang from virtual addressing being disabled from underneath it.  Work around this by enabling the accelerator to perform virtual address translation independent of the current privilege level.  Also added is a new custom instruction (funct7 = 2) for flushing the TLB.

Since `satp` continues to be shared with Rocket, this approach still relies on a `fence` instruction to precede each context switch.



This was tested in Linux on FireSim.