### PR TITLE
Fix SHA3-enabled builds

### DIFF
--- a/src/main/scala/ctrl.scala
+++ b/src/main/scala/ctrl.scala
@@ -57,8 +57,6 @@ class CtrlModule(val W: Int, val S: Int)(implicit val p: Parameters) extends Mod
     val buffer_out  = Bits(OUTPUT,width=W)
   }
 
-  require(coreParams.dcacheReqTagBits >= 7)
-
   //RoCC HANDLER
   //rocc pipe state
   val r_idle :: r_eat_addr :: r_eat_len :: Nil = Enum(UInt(), 3)


### PR DESCRIPTION
Rocket calculates the DCache tag size slightly differently with https://github.com/chipsalliance/rocket-chip/commit/cbeaadfd300a0b301775689ccae1ab6755d11a13 .

This requirement is no longer valid