### PR TITLE
Update bare-metal marshal workloads

### DIFF
--- a/software/marshal-configs/sha3-bare-rocc.yaml
+++ b/software/marshal-configs/sha3-bare-rocc.yaml
@@ -1,7 +1,7 @@
 {
   "name" : "sha3-bare-rocc",
   "workdir" : "..",
-  "base" : "bare",
+  "base" : "bare-base.json",
   "host-init" : "build.sh",
   "bin" : "tests/bare/sha3-rocc.riscv",
   "spike-args" : "--extension=sha3",

--- a/software/marshal-configs/sha3-bare-sw.yaml
+++ b/software/marshal-configs/sha3-bare-sw.yaml
@@ -1,7 +1,7 @@
 {
   "name" : "sha3-bare-sw",
   "workdir" : "..",
-  "base" : "bare",
+  "base" : "bare-base.json",
   "host-init" : "build.sh",
   "bin" : "tests/bare/sha3-sw.riscv",
   "testing" : {


### PR DESCRIPTION
The "bare" base has been deprecated in FireMarshal, workloads must use "bare-base.json".