### PR TITLE
Don't pattern-match the memset implementation

### DIFF
--- a/software/tests/bare/Makefile
+++ b/software/tests/bare/Makefile
@@ -1,7 +1,7 @@
 bmarkdir := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 TARGET := riscv64-unknown-elf
-CFLAGS := -mcmodel=medany -std=gnu99 -O2 -fno-common -fno-builtin-printf -Wall
+CFLAGS := -mcmodel=medany -std=gnu99 -O2 -fno-common -fno-builtin-printf -Wall -fno-tree-loop-distribute-patterns
 LDFLAGS := -static -nostdlib -nostartfiles -lgcc
 
 PROGRAMS := sha3-rocc sha3-sw


### PR DESCRIPTION
Fixes SW bugs with gcc 12